### PR TITLE
rpm build fix

### DIFF
--- a/prefix_list_agent/__meta__.py
+++ b/prefix_list_agent/__meta__.py
@@ -15,7 +15,7 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
-__version__ = "0.1.2.rc1"
+__version__ = "0.1.2.rc2"
 __author__ = "Ben Maddison"
 __author_email__ = "benm@workonline.africa"
 __licence__ = "MIT"

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ prefix=/usr
 universal = 1
 
 [bdist_rpm]
-python = /usr/bin/python
+python = /usr/bin/python2
 dist-dir = bdist_rpm
 
 [tool:pytest]


### PR DESCRIPTION
- explicitly pin python interpreter version
- bump version
